### PR TITLE
Suppress the 'Fatal: not a git repository' errors

### DIFF
--- a/radar-base.sh
+++ b/radar-base.sh
@@ -95,7 +95,7 @@ fetch() {
 
 commit_short_sha() {
   if is_repo; then
-    printf '%s' "$(git rev-parse --short HEAD)"
+    printf '%s' "$(git rev-parse --short HEAD 2>/dev/null)"
   fi
 }
 


### PR DESCRIPTION
This one command was not silenced and caused the mentioned error when the working directory is not a git repo.
