### PR TITLE
adding explicit output for error stream

### DIFF
--- a/git-radar
+++ b/git-radar
@@ -77,7 +77,7 @@ while [[ $# > 0 ]];do
   shift
 
   if [[ "$command" == "--fetch" ]]; then
-    nohup $dot/fetch.sh >/dev/null &
+    nohup $dot/fetch.sh >/dev/null 2>&1 &
   fi
   if [[ "$command" == "--zsh" ]]; then
     $dot/prompt.zsh


### PR DESCRIPTION
Fixes the issue discussed in #13.

`nohup: redirecting stderr to stdout`

This issue occasionally crash git and mess the lock file of a repository.
