### PR TITLE
issue-17: Add arguments to make the prompt shorter

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,21 +137,6 @@ export PS1="$PS1\$(git-radar --bash --fetch)"
 export PROMPT="$PROMPT$(git-radar --zsh --fetch) "
 ```
 
-### (Optional) Minimal mode
-
-If you wish to keep the length of your prompt shorter, you can call git-radar with `--minimal` which will render the new prompt without the `git:` part
-
-**Bash**
-```bash
-export PS1="$PS1\$(git-radar --bash --fetch --minimal) "
-```
-(note: the `\` escaping the `$` is important)
-
-**Zsh**
-```zsh
-export PROMPT="$PROMPT$(git-radar --zsh --fetch --minimal) "
-```
-
 ## License
 
 Git Radar is licensed under the MIT license.

--- a/README.md
+++ b/README.md
@@ -102,6 +102,19 @@ Prompt                     | Meaning
 ![git:(m 4 → my-branch)]   | There are 4 commits on `origin/master` that aren't on `origin/my-branch`
 ![git:(m 1 ⇄ 2 my-branch)] | `origin/master` and `origin/my-branch` have diverged, we'll need to rebase or merge
 
+If you don't rely on this status, you can always hide this part of the prompt by calling git-radar with `--no-remote-status`.
+
+**Bash**
+```bash
+export PS1="$PS1\$(git-radar --bash --fetch --no-remote-status) "
+```
+(note: the `\` escaping the `$` is important)
+
+**Zsh**
+```zsh
+export PROMPT="$PROMPT$(git-radar --zsh --fetch --no-remote-status) "
+```
+
 ### (Optional) Auto-fetch repos
 
 Ensuring your refs are up to date I found can be a pain. To streamline this
@@ -122,6 +135,21 @@ export PS1="$PS1\$(git-radar --bash --fetch)"
 **Zsh**
 ```zsh
 export PROMPT="$PROMPT$(git-radar --zsh --fetch) "
+```
+
+### (Optional) Minimal mode
+
+If you wish to keep the length of your prompt shorter, you can call git-radar with `--minimal` which will render the new prompt without the `git:` part
+
+**Bash**
+```bash
+export PS1="$PS1\$(git-radar --bash --fetch --minimal) "
+```
+(note: the `\` escaping the `$` is important)
+
+**Zsh**
+```zsh
+export PROMPT="$PROMPT$(git-radar --zsh --fetch --minimal) "
 ```
 
 ## License

--- a/git-radar
+++ b/git-radar
@@ -11,6 +11,7 @@ else
 fi
 
 dot="$(cd "$(dirname "$([ -L "$0" ] && $READLINK_CMD -f "$0" || echo "$0")")"; pwd)"
+args=$@
 
 if [[ -z $@ ]]; then
   _git="\033[1;30mgit:(\033[0m"
@@ -92,9 +93,9 @@ while [[ $# > 0 ]];do
     nohup $dot/fetch.sh >/dev/null 2>&1 &
   fi
   if [[ "$command" == "--zsh" ]]; then
-    $dot/prompt.zsh
+    $dot/prompt.zsh $args
   fi
   if [[ "$command" == "--bash" || "$command" == "--fish" ]]; then
-    $dot/prompt.bash
+    $dot/prompt.bash $args
   fi
 done

--- a/prompt.bash
+++ b/prompt.bash
@@ -1,11 +1,18 @@
 #! /usr/bin/env bash
 
 dot="$(cd "$(dirname "$0")"; pwd)"
+git_label=""
+args=$@
 source "$dot/radar-base.sh"
 
 if is_repo; then
-  printf " \x01\033[1;30m\x02git:(\x01\033[0m\x02"
-  bash_color_remote_commits
+  if show_git_label $args; then
+    git_label="git:"
+  fi
+  printf " \x01\033[1;30m\x02$git_label(\x01\033[0m\x02"
+  if show_remote_status $args; then
+    bash_color_remote_commits
+  fi
   readable_branch_name
   bash_color_local_commits
   printf "\x01\033[1;30m\x02)\x01\033[0m\x02"

--- a/prompt.bash
+++ b/prompt.bash
@@ -1,15 +1,11 @@
 #! /usr/bin/env bash
 
 dot="$(cd "$(dirname "$0")"; pwd)"
-git_label=""
 args=$@
 source "$dot/radar-base.sh"
 
 if is_repo; then
-  if show_git_label $args; then
-    git_label="git:"
-  fi
-  printf " \x01\033[1;30m\x02$git_label(\x01\033[0m\x02"
+  printf " \x01\033[1;30m\x02git:(\x01\033[0m\x02"
   if show_remote_status $args; then
     bash_color_remote_commits
   fi

--- a/prompt.zsh
+++ b/prompt.zsh
@@ -1,12 +1,15 @@
 #! /usr/bin/env zsh
 
 dot="$(cd "$(dirname "$0")"; pwd)"
+args=$@
 source "$dot/radar-base.sh"
 
 if is_repo; then
   autoload colors && colors
   printf '%s' "%{$fg_bold[black]%} git:(%{$reset_color%}"
-  zsh_color_remote_commits
+  if show_remote_status $args; then
+    zsh_color_remote_commits
+  fi
   readable_branch_name
   zsh_color_local_commits
   printf '%s' "%{$fg_bold[black]%})%{$reset_color%}"

--- a/radar-base.sh
+++ b/radar-base.sh
@@ -1,3 +1,6 @@
+IS_MINIMAL='--minimal'
+NO_REMOTE_STATUS='--no-remote-status'
+
 dot_git=""
 cwd=""
 remote=""
@@ -468,4 +471,18 @@ zsh_color_remote_commits() {
   fi
 
   printf %s "$remote"
+}
+
+show_git_label() {
+  if [[ $@ == *$IS_MINIMAL* ]]; then
+    return 1 # don't show the git label
+  fi
+  return 0
+}
+
+show_remote_status() {
+  if [[ $@ == *$NO_REMOTE_STATUS* ]]; then
+    return 1 # don't show the git remote status
+  fi
+  return 0
 }

--- a/radar-base.sh
+++ b/radar-base.sh
@@ -1,4 +1,3 @@
-IS_MINIMAL='--minimal'
 NO_REMOTE_STATUS='--no-remote-status'
 
 dot_git=""
@@ -472,14 +471,6 @@ zsh_color_remote_commits() {
 
   printf %s "$remote"
 }
-
-show_git_label() {
-  if [[ $@ == *$IS_MINIMAL* ]]; then
-    return 1 # don't show the git label
-  fi
-  return 0
-}
-
 show_remote_status() {
   if [[ $@ == *$NO_REMOTE_STATUS* ]]; then
     return 1 # don't show the git remote status

--- a/test
+++ b/test
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+./test-radar-base.sh
 ./test-directories.sh
 ./test-commits.sh
 ./test-branches.sh

--- a/test-radar-base.sh
+++ b/test-radar-base.sh
@@ -2,29 +2,6 @@ scriptDir="$(cd "$(dirname "$0")"; pwd)"
 
 source "$scriptDir/radar-base.sh"
 
-test_show_git_label() {
-  show_git_label
-  assertTrue $?
-
-  show_git_label --bash
-  assertTrue $?
-
-  show_git_label --bash --fetch
-  assertTrue $?
-
-  show_git_label --bash --minimal --fetch
-  assertFalse $?
-
-  show_git_label --bash --fetch --minimal
-  assertFalse $?
-
-  show_git_label --minimal --bash --fetch
-  assertFalse $?
-
-  show_git_label --bash --fetch  --minimal --no-remote-status
-  assertFalse $?
-}
-
 test_show_remote_status() {
   show_remote_status
   assertTrue $?

--- a/test-radar-base.sh
+++ b/test-radar-base.sh
@@ -1,0 +1,51 @@
+scriptDir="$(cd "$(dirname "$0")"; pwd)"
+
+source "$scriptDir/radar-base.sh"
+
+test_show_git_label() {
+  show_git_label
+  assertTrue $?
+
+  show_git_label --bash
+  assertTrue $?
+
+  show_git_label --bash --fetch
+  assertTrue $?
+
+  show_git_label --bash --minimal --fetch
+  assertFalse $?
+
+  show_git_label --bash --fetch --minimal
+  assertFalse $?
+
+  show_git_label --minimal --bash --fetch
+  assertFalse $?
+
+  show_git_label --bash --fetch  --minimal --no-remote-status
+  assertFalse $?
+}
+
+test_show_remote_status() {
+  show_remote_status
+  assertTrue $?
+
+  show_remote_status --bash
+  assertTrue $?
+
+  show_remote_status --bash --fetch
+  assertTrue $?
+
+  show_remote_status --bash --no-remote-status --fetch
+  assertFalse $?
+
+  show_remote_status --bash --fetch --no-remote-status
+  assertFalse $?
+
+  show_remote_status --no-remote-status --bash --fetch
+  assertFalse $?
+
+  show_remote_status --bash --fetch  --minimal --no-remote-status
+  assertFalse $?
+}
+
+. ./shunit/shunit2


### PR DESCRIPTION
This is for issue https://github.com/michaeldfallen/git-radar/issues/17. Depending of the status of your git project the prompt rendered by git-radar could get a little long.

As per discussion in https://github.com/michaeldfallen/git-radar/issues/17, adding a `--minimal` arg to hide the `git:` part, and a `--no-remote-status` arg that will hide the remote commits status part.

This PR includes:
- Main code changes, to add the args described above
- Unit tests
- An update to `README.md` to add a description for these new args
