### PR TITLE
Work-around for #2.

### DIFF
--- a/radar-base.sh
+++ b/radar-base.sh
@@ -124,7 +124,7 @@ readable_branch_name() {
 remote_branch_name() {
   local localRef="\/$(branch_name)$"
   if [[ -n "$localRef" ]]; then
-    local remoteBranch="$(git for-each-ref --format='%(upstream:short)' refs/heads $localRef 2>/dev/null | grep $localRef)"
+    local remoteBranch="$(git for-each-ref --format='%(upstream:short)' refs/heads $localRef 2>/dev/null | grep $localRef | head -1)"
     if [[ -n $remoteBranch ]]; then
       printf '%s' $remoteBranch
       return 0


### PR DESCRIPTION
When a branch has more than one upstream revision (ex: origin/master and
origin2/master), `remote_branch_name` returns multiple references
concatenated together causing the git error shown below:

fatal: ambiguous argument 'origin/masterorigin2/master...HEAD': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
fatal: ambiguous argument 'origin/masterorigin2/master...HEAD': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'

This patch just picks the first of the upstream branches. A full fix
would allow the user to decide which upstream to track.
