### PR TITLE
Make the commits prefix configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,14 @@ export PS1="$PS1\$(git-radar --bash --fetch)"
 export PROMPT="$PROMPT$(git-radar --zsh --fetch) "
 ```
 
+### Commits Prefix
+
+By default, ` git:` will be used as the prefix for git-radar's prompt.
+You can set `GIT_RADAR_COMMITS_PREFIX` as an ENV variable
+with any prefix that you like. For example: `export GIT_RADAR_COMMITS_PREFIX="my-git:"`.
+
+If you don't want git-radar to show a prefix you can always set this ENV variable to `""`.
+
 ## License
 
 Git Radar is licensed under the MIT license.

--- a/prompt.bash
+++ b/prompt.bash
@@ -2,10 +2,16 @@
 
 dot="$(cd "$(dirname "$0")"; pwd)"
 args=$@
+commits_prefix=" git:"
 source "$dot/radar-base.sh"
 
 if is_repo; then
-  printf " \x01\033[1;30m\x02git:(\x01\033[0m\x02"
+  # using parameter expasion to allow the ENV variable to be set to empty ("")
+  # see: http://www.gnu.org/software/bash/manual/bashref.html#Shell-Parameter-Expansion
+  if [ ${GIT_RADAR_COMMITS_PREFIX+x} ]; then
+    commits_prefix=$GIT_RADAR_COMMITS_PREFIX
+  fi
+  printf "\x01\033[1;30m\x02$commits_prefix(\x01\033[0m\x02"
   if show_remote_status $args; then
     bash_color_remote_commits
   fi

--- a/prompt.zsh
+++ b/prompt.zsh
@@ -2,11 +2,17 @@
 
 dot="$(cd "$(dirname "$0")"; pwd)"
 args=$@
+commits_prefix=" git:"
 source "$dot/radar-base.sh"
 
 if is_repo; then
   autoload colors && colors
-  printf '%s' "%{$fg_bold[black]%} git:(%{$reset_color%}"
+  # using parameter expasion to allow the ENV variable to be set to empty ("")
+  # see: http://www.gnu.org/software/bash/manual/bashref.html#Shell-Parameter-Expansion
+  if [ ${GIT_RADAR_COMMITS_PREFIX+x} ]; then
+    commits_prefix=$GIT_RADAR_COMMITS_PREFIX
+  fi
+  printf '%s' "%{$fg_bold[black]%}$commits_prefix(%{$reset_color%}"
   if show_remote_status $args; then
     zsh_color_remote_commits
   fi


### PR DESCRIPTION
- This is for issues https://github.com/michaeldfallen/git-radar/issues/15 and https://github.com/michaeldfallen/git-radar/issues/17
- To keep the implementation as simple as possible the opening and closing parenthesis "(..)" will still be shown. The new GIT_RADAR_COMMITS_PREFIX will only affect/overwrite the `git:` part of the prefix.
- Also added documentation in the README file.

Please let me know if you have any feedback, suggestions or questions.

Thanks!
