### PR TITLE
Fix bug with the view of colored branch name in bash

### DIFF
--- a/radar-base.sh
+++ b/radar-base.sh
@@ -182,7 +182,7 @@ branch_ref() {
 
 readable_branch_name() {
   if is_repo; then
-    printf '%s' "$COLOR_BRANCH$(branch_name || printf '%s' "detached@$(commit_short_sha)")$RESET_COLOR_BRANCH"
+    printf "$COLOR_BRANCH$(branch_name || printf '%s' "detached@$(commit_short_sha)")$RESET_COLOR_BRANCH"
   fi
 }
 


### PR DESCRIPTION
Close https://github.com/michaeldfallen/git-radar/issues/55

Before:
![2015-09-04 17 35 47](https://cloud.githubusercontent.com/assets/13235519/9697428/9bd0e310-53a6-11e5-95e3-39c688ea504b.png)

After:
![2015-09-05 8 18 14](https://cloud.githubusercontent.com/assets/13235519/9697431/b4ffb35c-53a6-11e5-8b44-bb338c6dfc5e.png)
