### PR TITLE
Make git-radar independent from GREP_OPTIONS environment variable

### DIFF
--- a/radar-base.sh
+++ b/radar-base.sh
@@ -1,3 +1,5 @@
+unset GREP_OPTIONS # ensure default behaviour of grep command
+
 NO_REMOTE_STATUS='--no-remote-status'
 
 dot_git=""


### PR DESCRIPTION
I have the following line in `.zshrc`:

```
export GREP_OPTIONS="--color --line-number" # Make grep more user-friendly
```

As it turns out, this doesn't play well with `git-radar`, which assumes `grep`'s default behaviour. This PR unsets the environment variable `GREP_OPTIONS` to ensure `grep` behaves as expected.
