### PR TITLE
Merge render functions

### DIFF
--- a/prompt.bash
+++ b/prompt.bash
@@ -8,10 +8,10 @@ if is_repo; then
   prepare_bash_colors
   printf " \x01\033[1;30m\x02git:(\x01\033[0m\x02"
   if show_remote_status $args; then
-    bash_color_remote_commits
+    color_remote_commits
   fi
-  bash_readable_branch_name
-  bash_color_local_commits
+  readable_branch_name
+  color_local_commits
   printf "\x01\033[1;30m\x02)\x01\033[0m\x02"
-  bash_color_changes_status
+  color_changes_status
 fi

--- a/prompt.zsh
+++ b/prompt.zsh
@@ -10,10 +10,10 @@ if is_repo; then
   prepare_zsh_colors
   printf '%s' "%{$fg_bold[black]%} git:(%{$reset_color%}"
   if show_remote_status $args; then
-    zsh_color_remote_commits
+    color_remote_commits
   fi
-  zsh_readable_branch_name
-  zsh_color_local_commits
+  readable_branch_name
+  color_local_commits
   printf '%s' "%{$fg_bold[black]%})%{$reset_color%}"
-  zsh_color_changes_status
+  color_changes_status
 fi

--- a/radar-base.sh
+++ b/radar-base.sh
@@ -373,7 +373,7 @@ untracked_status() {
   printf '%s' "$untracked_string"
 }
 
-bash_color_changes_status() {
+color_changes_status() {
   local separator="${1:- }"
 
   local porcelain="$(porcelain_status)"
@@ -405,36 +405,12 @@ bash_color_changes_status() {
   printf $PRINT_F_OPTION "$changes"
 }
 
+bash_color_changes_status() {
+  color_changes_status
+}
+
 zsh_color_changes_status() {
-  local separator="${1:- }"
-
-  local porcelain="$(porcelain_status)"
-  local changes=""
-
-  if [[ -n "$porcelain" ]]; then
-    local staged_changes="$(staged_status "$porcelain" "$COLOR_CHANGES_STAGED" "$RESET_COLOR_CHANGES")"
-    local unstaged_changes="$(unstaged_status "$porcelain" "$COLOR_CHANGES_UNSTAGED" "$RESET_COLOR_CHANGES")"
-    local untracked_changes="$(untracked_status "$porcelain" "$COLOR_CHANGES_UNTRACKED" "$RESET_COLOR_CHANGES")"
-    local conflicted_changes="$(conflicted_status "$porcelain" "$COLOR_CHANGES_CONFLICTED" "$RESET_COLOR_CHANGES")"
-    if [[ -n "$staged_changes" ]]; then
-      staged_changes="$separator$staged_changes"
-    fi
-
-    if [[ -n "$unstaged_changes" ]]; then
-      unstaged_changes="$separator$unstaged_changes"
-    fi
-
-    if [[ -n "$conflicted_changes" ]]; then
-      conflicted_changes="$separator$conflicted_changes"
-    fi
-
-    if [[ -n "$untracked_changes" ]]; then
-      untracked_changes="$separator$untracked_changes"
-    fi
-
-    changes="$staged_changes$conflicted_changes$unstaged_changes$untracked_changes"
-  fi
-  printf $PRINT_F_OPTION "$changes"
+  color_changes_status
 }
 
 color_local_commits() {

--- a/radar-base.sh
+++ b/radar-base.sh
@@ -483,7 +483,7 @@ zsh_color_local_commits() {
   printf $PRINT_F_OPTION "$local_commits"
 }
 
-bash_color_remote_commits() {
+color_remote_commits() {
   local green_ahead_arrow="${COLOR_REMOTE_AHEAD}←$RESET_COLOR_REMOTE"
   local red_behind_arrow="${COLOR_REMOTE_BEHIND}→$RESET_COLOR_REMOTE"
   local yellow_diverged_arrow="${COLOR_REMOTE_DIVERGED}⇄$RESET_COLOR_REMOTE"
@@ -505,31 +505,16 @@ bash_color_remote_commits() {
   fi
 
   printf $PRINT_F_OPTION "$remote"
+}
+
+bash_color_remote_commits() {
+  color_remote_commits
 }
 
 zsh_color_remote_commits() {
-  local green_ahead_arrow="${COLOR_REMOTE_AHEAD}←$RESET_COLOR_REMOTE"
-  local red_behind_arrow="${COLOR_REMOTE_BEHIND}→$RESET_COLOR_REMOTE"
-  local yellow_diverged_arrow="${COLOR_REMOTE_DIVERGED}⇄$RESET_COLOR_REMOTE"
-  local not_upstream="${COLOR_REMOTE_NOT_UPSTREAM}⚡$RESET_COLOR_REMOTE"
-
-  if remote_branch="$(remote_branch_name)"; then
-    remote_ahead="$(remote_ahead_of_master "$remote_branch")"
-    remote_behind="$(remote_behind_of_master "$remote_branch")"
-
-    if [[ "$remote_behind" -gt "0" && "$remote_ahead" -gt "0" ]]; then
-      remote="$MASTER_SYMBOL $remote_behind $yellow_diverged_arrow $remote_ahead "
-    elif [[ "$remote_ahead" -gt "0" ]]; then
-      remote="$MASTER_SYMBOL $green_ahead_arrow $remote_ahead "
-    elif [[ "$remote_behind" -gt "0" ]]; then
-      remote="$MASTER_SYMBOL $remote_behind $red_behind_arrow "
-    fi
-  else
-    remote="upstream $not_upstream "
-  fi
-
-  printf $PRINT_F_OPTION "$remote"
+  color_remote_commits
 }
+
 show_remote_status() {
   if [[ $@ == *$NO_REMOTE_STATUS* ]]; then
     return 1 # don't show the git remote status

--- a/radar-base.sh
+++ b/radar-base.sh
@@ -437,7 +437,7 @@ zsh_color_changes_status() {
   printf $PRINT_F_OPTION "$changes"
 }
 
-bash_color_local_commits() {
+color_local_commits() {
   local separator="${1:- }"
 
   local green_ahead_arrow="${COLOR_LOCAL_AHEAD}↑$RESET_COLOR_LOCAL"
@@ -460,27 +460,12 @@ bash_color_local_commits() {
   printf $PRINT_F_OPTION "$local_commits"
 }
 
+bash_color_local_commits() {
+  color_local_commits
+}
+
 zsh_color_local_commits() {
-  local separator="${1:- }"
-
-  local ahead_arrow="${COLOR_LOCAL_AHEAD}↑$RESET_COLOR_LOCAL"
-  local behind_arrow="${COLOR_LOCAL_BEHIND}↓$RESET_COLOR_LOCAL"
-  local diverged_arrow="${COLOR_LOCAL_DIVERGED}⇵$RESET_COLOR_LOCAL"
-
-  local local_commits=""
-  if remote_branch="$(remote_branch_name)"; then
-    local_ahead="$(commits_ahead_of_remote "$remote_branch")"
-    local_behind="$(commits_behind_of_remote "$remote_branch")"
-
-    if [[ "$local_behind" -gt "0" && "$local_ahead" -gt "0" ]]; then
-      local_commits="$separator$local_behind$diverged_arrow$local_ahead"
-    elif [[ "$local_behind" -gt "0" ]]; then
-      local_commits="$separator$local_behind$behind_arrow"
-    elif [[ "$local_ahead" -gt "0" ]]; then
-      local_commits="$separator$local_ahead$ahead_arrow"
-    fi
-  fi
-  printf $PRINT_F_OPTION "$local_commits"
+  color_local_commits
 }
 
 color_remote_commits() {

--- a/radar-base.sh
+++ b/radar-base.sh
@@ -184,18 +184,6 @@ branch_ref() {
   fi
 }
 
-zsh_readable_branch_name() {
-  if is_repo; then
-    printf '%s' "$COLOR_BRANCH$(branch_name || printf '%s' "detached@$(commit_short_sha)")$RESET_COLOR_BRANCH"
-  fi
-}
-
-bash_readable_branch_name() {
-  if is_repo; then
-    printf "$COLOR_BRANCH$(branch_name || printf '%s' "detached@$(commit_short_sha)")$RESET_COLOR_BRANCH"
-  fi
-}
-
 remote_branch_name() {
   local localRef="\/$(branch_name)$"
   if [[ -n "$localRef" ]]; then
@@ -474,6 +462,20 @@ bash_color_remote_commits() {
 
 zsh_color_remote_commits() {
   color_remote_commits
+}
+
+readable_branch_name() {
+  if is_repo; then
+    printf $PRINT_F_OPTION "$COLOR_BRANCH$(branch_name || printf '%s' "detached@$(commit_short_sha)")$RESET_COLOR_BRANCH"
+  fi
+}
+
+zsh_readable_branch_name() {
+  readable_branch_name
+}
+
+bash_readable_branch_name() {
+  readable_branch_name
 }
 
 show_remote_status() {

--- a/radar-base.sh
+++ b/radar-base.sh
@@ -12,6 +12,8 @@ prepare_bash_colors() {
     source "$rcfile_path/.gitradarrc"
   fi
 
+  PRINT_F_OPTION=""
+
   COLOR_REMOTE_AHEAD="\x01${GIT_RADAR_COLOR_REMOTE_AHEAD:-"\\033[1;32m"}\x02"
   COLOR_REMOTE_BEHIND="\x01${GIT_RADAR_COLOR_REMOTE_BEHIND:-"\\033[1;31m"}\x02"
   COLOR_REMOTE_DIVERGED="\x01${GIT_RADAR_COLOR_REMOTE_DIVERGED:-"\\033[1;33m"}\x02"
@@ -41,6 +43,8 @@ prepare_zsh_colors() {
   elif [ -f "$rcfile_path/.gitradarrc" ]; then
     source "$rcfile_path/.gitradarrc"
   fi
+
+  PRINT_F_OPTION="%s"
 
   COLOR_REMOTE_AHEAD="%{${GIT_RADAR_COLOR_REMOTE_AHEAD:-$fg_bold[green]}%}"
   COLOR_REMOTE_BEHIND="%{${GIT_RADAR_COLOR_REMOTE_BEHIND:-$fg_bold[red]}%}"
@@ -398,7 +402,7 @@ bash_color_changes_status() {
 
     changes="$staged_changes$conflicted_changes$unstaged_changes$untracked_changes"
   fi
-  printf "$changes"
+  printf $PRINT_F_OPTION "$changes"
 }
 
 zsh_color_changes_status() {
@@ -430,7 +434,7 @@ zsh_color_changes_status() {
 
     changes="$staged_changes$conflicted_changes$unstaged_changes$untracked_changes"
   fi
-  printf %s "$changes"
+  printf $PRINT_F_OPTION "$changes"
 }
 
 bash_color_local_commits() {
@@ -453,7 +457,7 @@ bash_color_local_commits() {
       local_commits="$separator$local_ahead$green_ahead_arrow"
     fi
   fi
-  printf "$local_commits"
+  printf $PRINT_F_OPTION "$local_commits"
 }
 
 zsh_color_local_commits() {
@@ -476,7 +480,7 @@ zsh_color_local_commits() {
       local_commits="$separator$local_ahead$ahead_arrow"
     fi
   fi
-  printf %s "$local_commits"
+  printf $PRINT_F_OPTION "$local_commits"
 }
 
 bash_color_remote_commits() {
@@ -500,7 +504,7 @@ bash_color_remote_commits() {
     remote="upstream $not_upstream "
   fi
 
-  printf "$remote"
+  printf $PRINT_F_OPTION "$remote"
 }
 
 zsh_color_remote_commits() {
@@ -524,7 +528,7 @@ zsh_color_remote_commits() {
     remote="upstream $not_upstream "
   fi
 
-  printf %s "$remote"
+  printf $PRINT_F_OPTION "$remote"
 }
 show_remote_status() {
   if [[ $@ == *$NO_REMOTE_STATUS* ]]; then

--- a/test-branches.sh
+++ b/test-branches.sh
@@ -56,6 +56,7 @@ test_detached_from_branch() {
   assertEquals "$sha" "$(branch_ref)"
   assertEquals "detached@$sha" "$(zsh_readable_branch_name)"
   assertEquals "detached@$sha" "$(bash_readable_branch_name)"
+  assertEquals "detached@$sha" "$(readable_branch_name)"
 
   rm_tmp
 }

--- a/test-colors.sh
+++ b/test-colors.sh
@@ -293,12 +293,14 @@ test_bash_colors_local() {
 
   printf -v expected " 1\x01local-ahead\x02↑\x01local-reset\x02"
   assertEquals "$expected" "$(bash_color_local_commits)"
+  assertEquals "$expected" "$(color_local_commits)"
 
   git push --quiet >/dev/null
   git reset --hard head^ --quiet >/dev/null
 
   printf -v expected " 1\x01local-behind\x02↓\x01local-reset\x02"
   assertEquals "$expected" "$(bash_color_local_commits)"
+  assertEquals "$expected" "$(color_local_commits)"
 
   echo "foo" > foo
   git add .
@@ -306,6 +308,7 @@ test_bash_colors_local() {
 
   printf -v expected " 1\x01local-diverged\x02⇵\x01local-reset\x021"
   assertEquals "$expected" "$(bash_color_local_commits)"
+  assertEquals "$expected" "$(color_local_commits)"
 
   rm_tmp
 }
@@ -379,6 +382,7 @@ test_bash_colors_remote() {
 
   printf -v expected "m 1 \x01remote-behind\x02→\x01remote-reset\x02 "
   assertEquals "$expected" "$(bash_color_remote_commits)"
+  assertEquals "$expected" "$(color_remote_commits)"
 
   echo "bar" > bar
   git add .
@@ -387,12 +391,14 @@ test_bash_colors_remote() {
 
   printf -v expected "m 1 \x01remote-diverged\x02⇄\x01remote-reset\x02 1 "
   assertEquals "$expected" "$(bash_color_remote_commits)"
+  assertEquals "$expected" "$(color_remote_commits)"
 
   git pull origin master --quiet >/dev/null
   git push --quiet >/dev/null
 
   printf -v expected "m \x01remote-ahead\x02←\x01remote-reset\x02 2 "
   assertEquals "$expected" "$(bash_color_remote_commits)"
+  assertEquals "$expected" "$(color_remote_commits)"
 
   rm_tmp
 }
@@ -459,6 +465,7 @@ test_bash_colors_changes() {
 
   printf -v expected " $staged $unstaged $untracked"
   assertEquals "$expected" "$(bash_color_changes_status)"
+  assertEquals "$expected" "$(color_changes_status)"
   rm_tmp
 }
 

--- a/test-commits.sh
+++ b/test-commits.sh
@@ -378,6 +378,7 @@ test_local_commits() {
 
   assertEquals "" "$(zsh_color_local_commits)"
   assertEquals "" "$(bash_color_local_commits)"
+  assertEquals "" "$(color_local_commits)"
 
   git init --quiet
   touch README
@@ -394,6 +395,7 @@ test_local_commits() {
 
   assertEquals "" "$(zsh_color_local_commits)"
   assertEquals "" "$(bash_color_local_commits)"
+  assertEquals "" "$(color_local_commits)"
 
   cd "$repo"
   echo "bar" > bar
@@ -402,6 +404,7 @@ test_local_commits() {
 
   assertEquals " 1$up" "$(zsh_color_local_commits)"
   assertEquals " 1$up" "$(bash_color_local_commits)"
+  assertEquals " 1$up" "$(color_local_commits)"
 
   cd "$remote"
   echo "foo" > foo
@@ -413,11 +416,13 @@ test_local_commits() {
 
   assertEquals " 1${both}1" "$(zsh_color_local_commits)"
   assertEquals " 1${both}1" "$(bash_color_local_commits)"
+  assertEquals " 1${both}1" "$(color_local_commits)"
 
   git reset --hard HEAD^ --quiet
 
   assertEquals " 1$down" "$(zsh_color_local_commits)"
   assertEquals " 1$down" "$(bash_color_local_commits)"
+  assertEquals " 1$down" "$(color_local_commits)"
 }
 
 . ./shunit/shunit2


### PR DESCRIPTION
Ends up the different render functions are identical, `[zsh|bash]_color_local_commits` for example had only one difference (the `printf` was given a different option).

This pull request cleans that up by providing a shared function and parameterising the `printf`parameter, so that both bash and zsh can use the same function. 

For backwards compatibility I have included the original functions but I think we can remove them soon. Maybe a deprecation message? or something like that?
