### PR TITLE
Fix #2 branches with same name in multiple remotes

### DIFF
--- a/radar-base.sh
+++ b/radar-base.sh
@@ -199,10 +199,15 @@ branch_ref() {
 remote_branch_name() {
   local localRef="\/$(branch_name)$"
   if [[ -n "$localRef" ]]; then
-    local remoteBranch="$(git for-each-ref --format='%(upstream:short)' refs/heads $localRef 2>/dev/null | grep $localRef)"
-    if [[ -n $remoteBranch ]]; then
-      printf '%s' $remoteBranch
-      return 0
+    local remote="$(git config --get-regexp "^branch\.$localRef\.remote" | awk '{print $2}')"
+    if [[ -n $remote ]]; then
+      local remoteBranch="$(git config --get-regexp "^branch\.${localRef}\.merge" | awk -F'/' '{print $NF}')"
+      if [[ -n $remoteBranch ]]; then
+        printf '%s/%s' $remote $remoteBranch
+        return 0
+      else
+          return 1
+      fi
     else
       return 1
     fi


### PR DESCRIPTION
Use `git config` to get the correct upstream remote and branch when you
have branch with the same name in multiple remotes (e.g. "origin/master"
and "coworker/master"). Uses awk which may be a problem?
