### PR TITLE
Escape all forward slashes

### DIFF
--- a/radar-base.sh
+++ b/radar-base.sh
@@ -517,7 +517,7 @@ render_prompt() {
     fi
   fi
   if [[ $PROMPT_FORMAT =~ ${if_pre}branch${if_post} ]]; then
-    branch_result="$(readable_branch_name | sed -e 's/\//\\\//')"
+    branch_result="$(readable_branch_name | sed -e 's/\//\\\//g')"
     if [[ -n "$branch_result" ]]; then
       branch_sed="s/${sed_pre}branch${sed_post}/\2${branch_result}\4/"
     else


### PR DESCRIPTION
Without the 'g' flag only the first one will be replaced.
This leads to errors with branches like wip/user/hotfix.
