### PR TITLE
Experiment: ZSH only version of async files changes

### DIFF
--- a/radar-base.sh
+++ b/radar-base.sh
@@ -433,7 +433,7 @@ untracked_status() {
 
 color_changes_status() {
   _async_changes() {
-    local zsh_parent_pid="$1"
+    local parent_pid="$1"
     local separator="${2:- }"
 
     local porcelain="$(porcelain_status)"
@@ -464,19 +464,16 @@ color_changes_status() {
     fi
 
     printf $PRINT_F_OPTION "${changes:1}"
-    kill -s USR1 "$zsh_parent_pid"
+    kill -s USR1 "$parent_pid" # Tell the parent we are finished
   }
-
-  zsh_parent_pid="$(top_zsh_pid "$PPID")"
 
   if [[ -f $(dot_git)/git_radar_changes ]]; then
     cat $(dot_git)/git_radar_changes
   fi
-  if [[ ! -f $(dot_git)/git_radar_working ]]; then
-    (_async_changes "$zsh_parent_pid")&> $(dot_git)/git_radar_changes &
-    touch $(dot_git)/git_radar_working
-  else
-    rm $(dot_git)/git_radar_working
+
+  GIT_RADAR_REDRAW=${GIT_RADAR_REDRAW:-false}
+  if ! $GIT_RADAR_REDRAW; then
+    (_async_changes "$GIT_RADAR_ZSH_PID")&> $(dot_git)/git_radar_changes &
   fi
 }
 

--- a/radar-base.sh
+++ b/radar-base.sh
@@ -411,19 +411,25 @@ untracked_status() {
 
 async_or_not() {
   local function_to_run="$1"
-  local file="$(dot_git)/async_git_radar_$2"
-  local working_file="$(dot_git)/async_git_radar_workers"
 
-  if [[ -f $file ]]; then
-    cat $file
-  fi
+  GIT_RADAR_ASYNC_EXEC=${GIT_RADAR_ASYNC_EXEC:-false}
+  if $GIT_RADAR_ASYNC_EXEC; then
+    local file="$(dot_git)/async_git_radar_$2"
+    local working_file="$(dot_git)/async_git_radar_workers"
 
-  GIT_RADAR_REDRAW=${GIT_RADAR_REDRAW:-false}
-  if ! $GIT_RADAR_REDRAW; then
-    (
-      eval $function_to_run > $file
-      kill -s USR1 "$GIT_RADAR_ZSH_PID" # Tell the parent we are finished
-    ) > /dev/null &
+    if [[ -f $file ]]; then
+      cat $file
+    fi
+
+    GIT_RADAR_REDRAW=${GIT_RADAR_REDRAW:-false}
+    if ! $GIT_RADAR_REDRAW; then
+      (
+        eval $function_to_run > $file
+        kill -s USR1 "$GIT_RADAR_ZSH_PID" # Tell the parent we are finished
+      ) > /dev/null &
+    fi
+  else
+    eval $function_to_run
   fi
 }
 

--- a/radar-base.sh
+++ b/radar-base.sh
@@ -583,7 +583,7 @@ render_prompt() {
   sed_post="\(\:\([^%^{^}]*\)\)\{0,1\}}"
 
   if [[ $output =~ ${if_pre}remote${if_post} ]]; then
-    remote_result="$(color_remote_commits)"
+    remote_result="$(async_or_not "color_remote_commits")"
     if [[ -n "$remote_result" ]]; then
       remote_sed="s/${sed_pre}remote${sed_post}/\2${remote_result}\4/"
     else

--- a/radar-base.sh
+++ b/radar-base.sh
@@ -416,16 +416,17 @@ async_or_not() {
   if $GIT_RADAR_ASYNC_EXEC; then
     local file="$(dot_git)/async_git_radar_$1"
 
-    if [[ -f $file ]]; then
-      cat $file
-    fi
-
     GIT_RADAR_REDRAW=${GIT_RADAR_REDRAW:-false}
     if ! $GIT_RADAR_REDRAW; then
       (
-        eval $function_to_run > $file
+        output="$($function_to_run)"
+        printf '%s' "$output" > $file
         kill -s USR1 "$GIT_RADAR_ZSH_PID" # Tell the parent we are finished
       ) > /dev/null &
+    fi
+
+    if [[ -f $file ]]; then
+      cat $file
     fi
   else
     eval $function_to_run

--- a/radar-base.sh
+++ b/radar-base.sh
@@ -27,28 +27,6 @@ get_fetch_time() {
   echo $FETCH_TIME
 }
 
-function top_zsh_pid {
-  # Look up the parent of the given PID.
-  pid="${1:-$$}"
-  found_zsh="${2}"
-  ppid="$(ps -p $pid -o ppid=)"
-  ppid_name="$(ps -p $ppid -o comm=)"
-
-  #printf "${ppid}:${ppid_name} -> "
-
-  # /sbin/init always has a PID of 1, so if you reach that, the current PID is
-  # the top-level parent. Otherwise, keep looking.
-  if [[ ${ppid} -eq 1 ]] ; then
-    printf "${ppid}"
-  elif [[ ${ppid_name} == *zsh* ]]; then
-    top_zsh_pid "${ppid}" "true"
-  elif [[ $found_zsh == "true" ]]; then
-    printf "${pid}"
-  else
-    top_zsh_pid "${ppid}" "false"
-  fi
-}
-
 prepare_bash_colors() {
   if [ -f "$rcfile_path/.gitradarrc.bash" ]; then
     source "$rcfile_path/.gitradarrc.bash"

--- a/radar-base.sh
+++ b/radar-base.sh
@@ -591,7 +591,7 @@ render_prompt() {
     fi
   fi
   if [[ $PROMPT_FORMAT =~ ${if_pre}branch${if_post} ]]; then
-    branch_result="$(readable_branch_name | sed -e 's/\//\\\//g')"
+    branch_result="$(async_or_not "readable_branch_name" | sed -e 's/\//\\\//g')"
     if [[ -n "$branch_result" ]]; then
       branch_sed="s/${sed_pre}branch${sed_post}/\2${branch_result}\4/"
     else

--- a/radar-base.sh
+++ b/radar-base.sh
@@ -468,7 +468,7 @@ color_changes_status() {
     printf $PRINT_F_OPTION "${changes:1}"
   }
 
-  async_or_not "_async_changes '$GIT_RADAR_ZSH_PID'" "changes"
+  async_or_not "_async_changes" "changes"
 }
 
 bash_color_changes_status() {

--- a/radar-base.sh
+++ b/radar-base.sh
@@ -599,7 +599,7 @@ render_prompt() {
     fi
   fi
   if [[ $PROMPT_FORMAT =~ ${if_pre}local${if_post} ]]; then
-    local_result="$(color_local_commits)"
+    local_result="$(async_or_not "color_local_commits")"
     if [[ -n "$local_result" ]]; then
       local_sed="s/${sed_pre}local${sed_post}/\2$local_result\4/"
     else

--- a/radar-base.sh
+++ b/radar-base.sh
@@ -615,7 +615,7 @@ render_prompt() {
     fi
   fi
   if [[ $PROMPT_FORMAT =~ ${if_pre}stash${if_post} ]]; then
-    stash_result="$(stash_status)"
+    stash_result="$(async_or_not "stash_status")"
     if [[ -n "$stash_result" ]]; then
       stash_sed="s/${sed_pre}stash${sed_post}/\2${stash_result}\4/"
     else


### PR DESCRIPTION
This pull request is an experiment. If you use ZSH please pull it and try it out as I'm looking for feedback.

In this pull request I have taken the longest part of the radar, the file changes (0.245s out of 0.25s on my machine), and made it async. It now `cat`'s a file in `.git` and spawns an async subshell to populate that file. Then using ZSH's `zle reset-prompt` we are able to cause the shell to re-render once the async subshell has completed.

![async-radar](https://cloud.githubusercontent.com/assets/1446145/10632327/b463603e-77db-11e5-9f17-77bc866c2bc1.gif)

It's flaky and hacky and only a first pass but it does mean the initial prompt render is almost instantaneous. The file changes then asynchronously populate later.

**To use**:

You need to add a definition for the zsh function `TRAPUSR1` to your `.zshrc`:

```
function TRAPUSR1() {
  # redisplay the prompt
  zle && zle reset-prompt
}
```
