### PR TITLE
Switch untracked symbol

### DIFF
--- a/radar-base.sh
+++ b/radar-base.sh
@@ -405,7 +405,7 @@ untracked_status() {
   local filesUntracked="$(printf '%s' "$gitStatus" | grep "?? " | wc -l | grep -oEi '[1-9][0-9]*')"
 
   if [ -n "$filesUntracked" ]; then
-    untracked_string="$untracked_string$filesUntracked${prefix}A${suffix}"
+    untracked_string="$untracked_string$filesUntracked${prefix}?${suffix}"
   fi
   printf '%s' "$untracked_string"
 }

--- a/test-colors.sh
+++ b/test-colors.sh
@@ -459,7 +459,7 @@ test_bash_colors_changes() {
   touch bar
   git add bar
   echo "bar" > bar
-  untracked="1\x01changes-untracked\x02A\x01change-reset\x02"
+  untracked="1\x01changes-untracked\x02?\x01change-reset\x02"
   unstaged="1\x01changes-unstaged\x02M\x01change-reset\x02"
   staged="1\x01changes-staged\x02A\x01change-reset\x02"
 
@@ -481,7 +481,7 @@ test_zsh_colors_changes() {
   touch bar
   git add bar
   echo "bar" > bar
-  untracked="1%{changes-untracked%}A%{change-reset%}"
+  untracked="1%{changes-untracked%}?%{change-reset%}"
   unstaged="1%{changes-unstaged%}M%{change-reset%}"
   staged="1%{changes-staged%}A%{change-reset%}"
 

--- a/test-files.sh
+++ b/test-files.sh
@@ -22,7 +22,7 @@ test_untracked_files() {
   assertEquals "" "$(untracked_status)"
 
   touch foo
-  assertEquals "1A" "$(untracked_status)"
+  assertEquals "1?" "$(untracked_status)"
 
   git add .
   assertEquals "" "$(untracked_status)"

--- a/test-format-config.sh
+++ b/test-format-config.sh
@@ -91,28 +91,28 @@ test_all_options_set_config() {
   unset_colours
 
   prompt="$(render_prompt)"
-  assertEquals "$prompt" "m 1 →foo1↑1A"
+  assertEquals "$prompt" "m 1 →foo1↑1?"
 
   export GIT_RADAR_FORMAT="%{remote}%{branch}%{changes}"
   prepare_zsh_colors
   unset_colours
 
   prompt="$(render_prompt)"
-  assertEquals "$prompt" "m 1 →foo1A"
+  assertEquals "$prompt" "m 1 →foo1?"
 
   export GIT_RADAR_FORMAT="%{branch}%{local}%{changes}"
   prepare_zsh_colors
   unset_colours
 
   prompt="$(render_prompt)"
-  assertEquals "$prompt" "foo1↑1A"
+  assertEquals "$prompt" "foo1↑1?"
 
   export GIT_RADAR_FORMAT="%{branch}%{changes}"
   prepare_zsh_colors
   unset_colours
 
   prompt="$(render_prompt)"
-  assertEquals "$prompt" "foo1A"
+  assertEquals "$prompt" "foo1?"
 
   export GIT_RADAR_FORMAT="%{branch}"
   prepare_zsh_colors

--- a/test-format-config.sh
+++ b/test-format-config.sh
@@ -124,111 +124,111 @@ test_all_options_set_config() {
   rm_tmp
 }
 
-#test_reorder_parts() {
-#  prepare_test_repo
-#
-#  export GIT_RADAR_FORMAT="%{branch}%{local}%{changes}%{remote}"
-#  prepare_zsh_colors
-#  unset_colours
-#
-#  prompt="$(render_prompt)"
-#  assertEquals "foo1↑1Am 1 →" "$prompt"
-#
-#  export GIT_RADAR_FORMAT="%{local}%{changes}%{remote}%{branch}"
-#  prepare_zsh_colors
-#  unset_colours
-#
-#  prompt="$(render_prompt)"
-#  assertEquals "1↑1Am 1 →foo" "$prompt"
-#
-#  export GIT_RADAR_FORMAT="%{changes}%{remote}%{branch}%{local}"
-#  prepare_zsh_colors
-#  unset_colours
-#
-#  prompt="$(render_prompt)"
-#  assertEquals "1Am 1 →foo1↑" "$prompt"
-#
-#  rm_tmp
-#}
-#
-#test_prefix_and_suffix_changes() {
-#  prepare_test_repo
-#
-#  export GIT_RADAR_FORMAT="%{changes}"
-#  prepare_zsh_colors
-#  unset_colours
-#
-#  prompt="$(render_prompt)"
-#  assertEquals "1A" "$prompt"
-#
-#  export GIT_RADAR_FORMAT="%{[:changes:]}"
-#  prepare_zsh_colors
-#  unset_colours
-#
-#  prompt="$(render_prompt)"
-#  assertEquals "[1A]" "$prompt"
-#
-#  rm_tmp
-#}
-#
-#test_prefix_and_suffix_local() {
-#  prepare_test_repo
-#
-#  export GIT_RADAR_FORMAT="%{local}"
-#  prepare_zsh_colors
-#  unset_colours
-#
-#  prompt="$(render_prompt)"
-#  assertEquals "1↑" "$prompt"
-#
-#  export GIT_RADAR_FORMAT="%{[:local:]}"
-#  prepare_zsh_colors
-#  unset_colours
-#
-#  prompt="$(render_prompt)"
-#  assertEquals "[1↑]" "$prompt"
-#
-#  rm_tmp
-#}
-#
-#test_prefix_and_suffix_branch() {
-#  prepare_test_repo
-#
-#  export GIT_RADAR_FORMAT="%{branch}"
-#  prepare_zsh_colors
-#  unset_colours
-#
-#  prompt="$(render_prompt)"
-#  assertEquals "foo" "$prompt"
-#
-#  export GIT_RADAR_FORMAT="%{[:branch:]}"
-#  prepare_zsh_colors
-#  unset_colours
-#
-#  prompt="$(render_prompt)"
-#  assertEquals "[foo]" "$prompt"
-#
-#  rm_tmp
-#}
-#
-#test_prefix_and_suffix_remote() {
-#  prepare_test_repo
-#
-#  export GIT_RADAR_FORMAT="%{remote}"
-#  prepare_zsh_colors
-#  unset_colours
-#
-#  prompt="$(render_prompt)"
-#  assertEquals "m 1 →" "$prompt"
-#
-#  export GIT_RADAR_FORMAT="%{[:remote:]}"
-#  prepare_zsh_colors
-#  unset_colours
-#
-#  prompt="$(render_prompt)"
-#  assertEquals "[m 1 →]" "$prompt"
-#
-#  rm_tmp
-#}
+test_reorder_parts() {
+  prepare_test_repo
+
+  export GIT_RADAR_FORMAT="%{branch}%{local}%{changes}%{remote}"
+  prepare_zsh_colors
+  unset_colours
+
+  prompt="$(render_prompt)"
+  assertEquals "foo1↑1?m 1 →" "$prompt"
+
+  export GIT_RADAR_FORMAT="%{local}%{changes}%{remote}%{branch}"
+  prepare_zsh_colors
+  unset_colours
+
+  prompt="$(render_prompt)"
+  assertEquals "1↑1?m 1 →foo" "$prompt"
+
+  export GIT_RADAR_FORMAT="%{changes}%{remote}%{branch}%{local}"
+  prepare_zsh_colors
+  unset_colours
+
+  prompt="$(render_prompt)"
+  assertEquals "1?m 1 →foo1↑" "$prompt"
+
+  rm_tmp
+}
+
+test_prefix_and_suffix_changes() {
+  prepare_test_repo
+
+  export GIT_RADAR_FORMAT="%{changes}"
+  prepare_zsh_colors
+  unset_colours
+
+  prompt="$(render_prompt)"
+  assertEquals "1?" "$prompt"
+
+  export GIT_RADAR_FORMAT="%{[:changes:]}"
+  prepare_zsh_colors
+  unset_colours
+
+  prompt="$(render_prompt)"
+  assertEquals "[1?]" "$prompt"
+
+  rm_tmp
+}
+
+test_prefix_and_suffix_local() {
+  prepare_test_repo
+
+  export GIT_RADAR_FORMAT="%{local}"
+  prepare_zsh_colors
+  unset_colours
+
+  prompt="$(render_prompt)"
+  assertEquals "1↑" "$prompt"
+
+  export GIT_RADAR_FORMAT="%{[:local:]}"
+  prepare_zsh_colors
+  unset_colours
+
+  prompt="$(render_prompt)"
+  assertEquals "[1↑]" "$prompt"
+
+  rm_tmp
+}
+
+test_prefix_and_suffix_branch() {
+  prepare_test_repo
+
+  export GIT_RADAR_FORMAT="%{branch}"
+  prepare_zsh_colors
+  unset_colours
+
+  prompt="$(render_prompt)"
+  assertEquals "foo" "$prompt"
+
+  export GIT_RADAR_FORMAT="%{[:branch:]}"
+  prepare_zsh_colors
+  unset_colours
+
+  prompt="$(render_prompt)"
+  assertEquals "[foo]" "$prompt"
+
+  rm_tmp
+}
+
+test_prefix_and_suffix_remote() {
+  prepare_test_repo
+
+  export GIT_RADAR_FORMAT="%{remote}"
+  prepare_zsh_colors
+  unset_colours
+
+  prompt="$(render_prompt)"
+  assertEquals "m 1 →" "$prompt"
+
+  export GIT_RADAR_FORMAT="%{[:remote:]}"
+  prepare_zsh_colors
+  unset_colours
+
+  prompt="$(render_prompt)"
+  assertEquals "[m 1 →]" "$prompt"
+
+  rm_tmp
+}
 
 . ./shunit/shunit2

--- a/test-status.sh
+++ b/test-status.sh
@@ -30,7 +30,7 @@ UU modified-both-conflicted
   assertEquals "line:${LINENO}" "1_U-1_T-1_B-"\
     "$(conflicted_status "$status" "$prefix" "$suffix")"
 
-  assertEquals "line:${LINENO}" "1_A-"\
+  assertEquals "line:${LINENO}" "1_?-"\
     "$(untracked_status "$status" "$prefix" "$suffix")"
 }
 


### PR DESCRIPTION
In #24 it was suggested we change the icon for untracked changes. This pull request changes that icon to `?`.

<img width="633" alt="screen shot 2015-10-29 at 12 16 54" src="https://cloud.githubusercontent.com/assets/1446145/10818126/f67ff322-7e36-11e5-982e-968f0879944e.png">
