### PR TITLE
Remove the dependency on “greadlink” for OS X. 

### DIFF
--- a/fetch.sh
+++ b/fetch.sh
@@ -1,12 +1,12 @@
 #! /usr/bin/env bash
 
 if [[ "$OSTYPE" == *darwin* ]]; then
-  READLINK_CMD='greadlink'
-else
   READLINK_CMD='readlink'
+else
+  READLINK_CMD='readlink -f'
 fi
 
-dot="$(cd "$(dirname "$([ -L "$0" ] && $READLINK_CMD -f "$0" || echo "$0")")"; pwd)"
+dot="$(cd "$(dirname "$([ -L "$0" ] && $READLINK_CMD "$0" || echo "$0")")"; pwd)"
 
 source $dot/radar-base.sh
 

--- a/git-radar
+++ b/git-radar
@@ -5,12 +5,12 @@
 # A heads up display for git
 
 if [[ "$OSTYPE" == *darwin* ]]; then
-  READLINK_CMD='greadlink'
-else
   READLINK_CMD='readlink'
+else
+  READLINK_CMD='readlink -f'
 fi
 
-dot="$(cd "$(dirname "$([ -L "$0" ] && $READLINK_CMD -f "$0" || echo "$0")")"; pwd)"
+dot="$(cd "$(dirname "$([ -L "$0" ] && $READLINK_CMD "$0" || echo "$0")")"; pwd)"
 args=$@
 
 if [[ -z $@ ]]; then


### PR DESCRIPTION
This should also remove the “coreutils” dependency in the homebrew formula.
