### PR TITLE
Add another prompt control string that prints out the current path relative to the repository root.

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,13 +215,14 @@ Git Radar is highly customisable using a prompt format string. The 4 features
 above: remote commits, local commits, branch and file changes; are controlled
 by the prompt format string.
 
-Feature        | Control string
----------------|---------------
-Remote commits | `%{remote}`
-Local commits  | `%{local}`
-Branch         | `%{branch}`
-File changes   | `%{changes}`
-Stashes        | `%{stash}`
+Feature                    | Control string
+---------------------------|---------------
+Remote commits             | `%{remote}`
+Local commits              | `%{local}`
+Branch                     | `%{branch}`
+File changes               | `%{changes}`
+Stashes                    | `%{stash}`
+Relative path in the repo  | `%{git_path}`
 
 You can create any prompt shape you prefer by exporting `GIT_RADAR_FORMAT` with
 your preferred shape. The control strings above will be replaced with the output

--- a/radar-base.sh
+++ b/radar-base.sh
@@ -543,6 +543,10 @@ stash_status() {
   fi
 }
 
+git_path() {
+  printf '%s' "$(basename `git rev-parse --show-toplevel`)/$(git rev-parse --show-prefix)"
+}
+
 render_prompt() {
   output="$PROMPT_FORMAT"
   branch_sed=""
@@ -550,7 +554,7 @@ render_prompt() {
   local_sed=""
   changes_sed=""
   stash_sed=""
-
+  git_path_sed=""
 
   if_pre="%\{([^%{}]{1,}:){0,1}"
   if_post="(:[^%{}]{1,}){0,1}\}"
@@ -597,11 +601,20 @@ render_prompt() {
       stash_sed="s/${sed_pre}stash${sed_post}//"
     fi
   fi
+  if [[ $PROMPT_FORMAT =~ ${if_pre}git_path${if_post} ]]; then
+    git_path_result="$(git_path | sed -e 's/[\/&]/\\&/g')"
+    if [[ -n "git_path_result" ]]; then
+      git_path_sed="s/${sed_pre}git_path${sed_post}/\2${git_path_result}\4/"
+    else
+      git_path_sed="s/${sed_pre}git_path${sed_post}//"
+    fi
+  fi
 
   printf '%b' "$output" | sed \
                             -e "$remote_sed" \
                             -e "$branch_sed" \
                             -e "$changes_sed" \
                             -e "$local_sed" \
-                            -e "$stash_sed"
+                            -e "$stash_sed" \
+                            -e "$git_path_sed"
 }


### PR DESCRIPTION
I find this useful as I do not print the full path in my prompt normally. This works especially well if you include a newline at the end of your git-radar prompt. Here is how it looks with my prompt:

![screen shot 2015-11-06 at 9 51 11 am](https://cloud.githubusercontent.com/assets/791055/11001302/1dd4b1a2-846c-11e5-9563-e4aa1ff4a96e.png)

My prompt string:

```
GIT_RADAR_FORMAT="\\x01\\033[1;32m\\x02→\\x01\\033[0m\\x02 \\x01\\033[1;36m\\x02%{git_path}\\x01\\033[0m\\x02 \\x01\\033[37m\\x02git:(\\x01\\033[0m\\x02%{remote: }%{branch}%{ :local}\\x01\\033[37m\\x02)\\x01\\033[0m\\x02%{ :stash}%{ :changes}\\x01\n\\x02"
```
