### PR TITLE
fixed double equals sign breaking zsh

### DIFF
--- a/radar-base.sh
+++ b/radar-base.sh
@@ -537,7 +537,7 @@ stashed_status() {
 }
 
 is_cwd_a_dot_git_directory() {
-  test "$(basename $PWD)" == ".git"; return $?
+  test "$(basename $PWD)" '==' ".git"; return $?
 }
 
 stash_status() {


### PR DESCRIPTION
wraps double equals `==` sign with quotes to be zsh compatible
