### PR TITLE
fix for basename: extra operand warning

### DIFF
--- a/radar-base.sh
+++ b/radar-base.sh
@@ -537,7 +537,7 @@ stashed_status() {
 }
 
 is_cwd_a_dot_git_directory() {
-  [[ "$(basename $PWD)" == ".git" ]]; return $?
+  [[ "$(basename "$PWD")" == ".git" ]]; return $?
 }
 
 stash_status() {


### PR DESCRIPTION
In deeper directories where parent folders contain spaces, git-radar will print this basename warning.

![git-radar-old](https://cloud.githubusercontent.com/assets/16403734/20870547/5c35997a-ba58-11e6-9ef7-a2f11be9c3ee.PNG)

Putting quotes around $PWD resolves this issue

![git-radar-new](https://cloud.githubusercontent.com/assets/16403734/20870549/63d69d32-ba58-11e6-9840-c60a06735b9d.PNG)
