### PR TITLE
Added a configuration option to suffix/prefix the prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,24 @@ The default prompt format uses this to add spaces only if the feature would
 render. In that way the prompt always looks well spaced out no matter how many
 features are rendering.
 
+### Prefixing and Suffixing the Full git-radar Prompt
+
+It may be that we want our git-radar prompt to be prefixed or suffixed by some
+string of characters, but only when you are in a repository.
+
+To do this, use the built in variables that can be assigned in a .gitradarrc
+file.
+
+For example:
+
+```bash
+GIT_RADAR_PROMPT_SUFFIX=" >> "
+GIT_RADAR_PROMPT_PREFIX=" << "
+```
+
+This will produce a prompt like this: `<< git:(master) >>`, where `<<` and `>>`
+only show, if we are actually in a git repository.
+
 
 ## Support
 

--- a/radar-base.sh
+++ b/radar-base.sh
@@ -56,7 +56,10 @@ prepare_bash_colors() {
   COLOR_BRANCH="\x01${GIT_RADAR_COLOR_BRANCH:-"\\033[0m"}\x02"
   MASTER_SYMBOL="${GIT_RADAR_MASTER_SYMBOL:-"\\x01\\033[0m\\x02\\xF0\\x9D\\x98\\xAE\\x01\\033[0m\\x02"}"
 
-  PROMPT_FORMAT="${GIT_RADAR_FORMAT:-" \\x01\\033[1;30m\\x02git:(\\x01\\033[0m\\x02%{remote: }%{branch}%{ :local}\\x01\\033[1;30m\\x02)\\x01\\033[0m\\x02%{ :stash}%{ :changes}"}"
+  PROMPT_FORMAT="${GIT_RADAR_FORMAT:-"\\x01\\033[1;30m\\x02git:(\\x01\\033[0m\\x02%{remote: }%{branch}%{ :local}\\x01\\033[1;30m\\x02)\\x01\\033[0m\\x02%{ :stash}%{ :changes}"}"
+
+  PROMPT_PREFIX="${GIT_RADAR_PROMPT_PREFIX:-" "}"
+  PROMPT_SUFFIX="${GIT_RADAR_PROMPT_SUFFIX:-""}"
 
   RESET_COLOR_LOCAL="\x01${GIT_RADAR_COLOR_LOCAL_RESET:-"\\033[0m"}\x02"
   RESET_COLOR_REMOTE="\x01${GIT_RADAR_COLOR_REMOTE_RESET:-"\\033[0m"}\x02"
@@ -96,7 +99,10 @@ prepare_zsh_colors() {
   COLOR_BRANCH="%{${GIT_RADAR_COLOR_BRANCH:-$reset_color}%}"
   MASTER_SYMBOL="${GIT_RADAR_MASTER_SYMBOL:-"%{$reset_color%}$italic_m%{$reset_color%}"}"
 
-  PROMPT_FORMAT="${GIT_RADAR_FORMAT:-" %{$fg_bold[grey]%}git:(%{$reset_color%}%{remote: }%{branch}%{ :local}%{$fg_bold[grey]%})%{$reset_color%}%{ :stash}%{ :changes}"}"
+  PROMPT_FORMAT="${GIT_RADAR_FORMAT:-"%{$fg_bold[grey]%}git:(%{$reset_color%}%{remote: }%{branch}%{ :local}%{$fg_bold[grey]%})%{$reset_color%}%{ :stash}%{ :changes}"}"
+
+  PROMPT_PREFIX="${GIT_RADAR_PROMPT_PREFIX:-" "}"
+  PROMPT_SUFFIX="${GIT_RADAR_PROMPT_SUFFIX:-""}"
 
   RESET_COLOR_LOCAL="%{${GIT_RADAR_COLOR_LOCAL_RESET:-$reset_color}%}"
   RESET_COLOR_REMOTE="%{${GIT_RADAR_COLOR_REMOTE_RESET:-$reset_color}%}"
@@ -604,7 +610,7 @@ render_prompt() {
     fi
   fi
 
-  printf '%b' "$output" | sed \
+  printf '%b' "${PROMPT_PREFIX}${output}${PROMPT_SUFFIX}" | sed \
                             -e "$remote_sed" \
                             -e "$branch_sed" \
                             -e "$changes_sed" \


### PR DESCRIPTION
Now, you can add a prefix and/or suffix to your git-radar prompt that
will only show if you are in a git repo.

Note: The PROMPT_FORMAT line was changed to remove the leading space in
the string. With it in, if you define a prefix a space will still be
there even if the user may not want it. So it can be overridden by the
user with one of the new variables, but by default, the prefix still
adds that space anyways.