### PR TITLE
Added TC for typechanged status

### DIFF
--- a/radar-base.sh
+++ b/radar-base.sh
@@ -337,6 +337,7 @@ staged_status() {
   local filesDeleted="$(printf '%s' "$gitStatus" | grep -oE "D[AMCR ] " | wc -l | grep -oEi '[1-9][0-9]*')"
   local filesRenamed="$(printf '%s' "$gitStatus" | grep -oE "R[AMCD ] " | wc -l | grep -oEi '[1-9][0-9]*')"
   local filesCopied="$(printf '%s' "$gitStatus" | grep -oE "C[AMDR ] " | wc -l | grep -oEi '[1-9][0-9]*')"
+  local typeChanged="$(printf '%s' "$gitStatus" | grep -oE "T[AMDR ] " | wc -l | grep -oEi '[1-9][0-9]*')"
 
   if [ -n "$filesAdded" ]; then
     staged_string="$staged_string$filesAdded${prefix}A${suffix}"
@@ -352,6 +353,9 @@ staged_status() {
   fi
   if [ -n "$filesCopied" ]; then
     staged_string="$staged_string$filesCopied${prefix}C${suffix}"
+  fi
+  if [ -n "$typeChanged" ]; then
+    staged_string="$staged_string$typeChanged${prefix}TC${suffix}"
   fi
   printf '%s' "$staged_string"
 }
@@ -386,12 +390,16 @@ unstaged_status() {
 
   local filesModified="$(printf '%s' "$gitStatus" | grep -oE "[ACDRM ]M " | wc -l | grep -oEi '[1-9][0-9]*')"
   local filesDeleted="$(printf '%s' "$gitStatus" | grep -oE "[AMCR ]D " | wc -l | grep -oEi '[1-9][0-9]*')"
+  local typeChanged="$(printf '%s' "$gitStatus" | grep -oE "[AMDR ]T " | wc -l | grep -oEi '[1-9][0-9]*')"
 
   if [ -n "$filesDeleted" ]; then
     unstaged_string="$unstaged_string$filesDeleted${prefix}D${suffix}"
   fi
   if [ -n "$filesModified" ]; then
     unstaged_string="$unstaged_string$filesModified${prefix}M${suffix}"
+  fi
+  if [ -n "$typeChanged" ]; then
+    unstaged_string="$unstaged_string$typeChanged${prefix}TC${suffix}"
   fi
   printf '%s' "$unstaged_string"
 }


### PR DESCRIPTION
I came across "typechanged" the other day in my git status. It occurs when (for example) you change a file from being a regular file, to a symlink.

Not sure if you want this in. I am using "TC" in the terminal to show this.

I would also like a check on the grep's in the lines that I added. I understand that everything inside of the square brackets can be matched, but I am unsure what letters I would also need with this.