### PR TITLE
Let the remote tracking branch be configurable

### DIFF
--- a/radar-base.sh
+++ b/radar-base.sh
@@ -264,9 +264,19 @@ commits_ahead_of_remote() {
   fi
 }
 
+determine_tracked_remote() {
+  by_branch=$(git config --local branch."$(git rev-parse --abbrev-ref HEAD)".git-radar-tracked-remote)
+  [[ ! -z $by_branch ]] && echo $by_branch && return 0
+
+  by_config=$(git config --local git-radar.tracked-remote)
+  [[ ! -z $by_config ]] && echo $by_config && return 0
+
+  echo "origin/master"
+}
+
 remote_behind_of_master() {
   remote_branch=${1:-"$(remote_branch_name)"}
-  tracked_remote="origin/master"
+  tracked_remote=$(determine_tracked_remote)
   if [[ -n "$remote_branch" && "$remote_branch" != "$tracked_remote" ]]; then
     git rev-list --left-only --count ${tracked_remote}...${remote_branch} 2>/dev/null || printf '%s' "0"
   else
@@ -276,7 +286,7 @@ remote_behind_of_master() {
 
 remote_ahead_of_master() {
   remote_branch=${1:-"$(remote_branch_name)"}
-  tracked_remote="origin/master"
+  tracked_remote=$(determine_tracked_remote)
   if [[ -n "$remote_branch" && "$remote_branch" != "$tracked_remote" ]]; then
     git rev-list --right-only --count ${tracked_remote}...${remote_branch} 2>/dev/null || printf '%s' "0"
   else


### PR DESCRIPTION
This commit allows the user to define a per repository or per branch
specific configuration of which branch git-radar compares the current
branch to. If no branch is configured explicitly "origin/master" will
be used (being backwards compatible with the current behaviour).

A branch specific remote tracking branch may be configured by executing

    git config --local branch."$(git rev-parse --abbrev-ref HEAD)".git-radar-tracked-remote origin/my-branch-to-compare-to

A repository specific remote tracking may be configured by executing

    git config --local git-radar.tracked-remote origin/my-branch-to-compare-to

A branch specific setting will overwrite a repository specific
configuration (which will overwrite the default, i.e origin/master).